### PR TITLE
fix: 🐛 use better workaround for lighthouse total byte width

### DIFF
--- a/lighthouserc.yml
+++ b/lighthouserc.yml
@@ -8,4 +8,4 @@ ci:
     assertions:
       csp-xss: "off"
       bf-cache: "warn"
-      total-byte-weight: ["error", {"maxNumericValue": 1677721600}] # TODO: remove this when this bug is fixed: https://github.com/GoogleChrome/lighthouse-ci/issues/994
+      total-byte-weight: ["error", { "maxNumericValue": 1677721600 }] # TODO: remove this when this bug is fixed: https://github.com/GoogleChrome/lighthouse-ci/issues/994

--- a/lighthouserc.yml
+++ b/lighthouserc.yml
@@ -8,4 +8,4 @@ ci:
     assertions:
       csp-xss: "off"
       bf-cache: "warn"
-      total-byte-weight: "off" # TODO: enable this when this bug is fixed: https://github.com/GoogleChrome/lighthouse-ci/issues/1001
+      total-byte-weight: ["error", {"maxNumericValue": 1677721600}] # TODO: remove this when this bug is fixed: https://github.com/GoogleChrome/lighthouse-ci/issues/994


### PR DESCRIPTION
https://github.com/GoogleChrome/lighthouse-ci/issues/994